### PR TITLE
Remove redundant npm dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,6 @@
     "install": "^0.12.2",
     "libphonenumber-js": "^1.7.9",
     "loglevel": "^1.6.1",
-    "npm": "^6.8.0",
     "radium": "^0.25.1",
     "react": "^16.8.3",
     "react-animations": "^1.0.0",


### PR DESCRIPTION

Hello slicktdog08!

It seems like you have npm as one of your (dev-) dependency in tyler-resume.
Since you actually need npm to install the dependencies it's redundant to
have npm itself as (dev-) dependency. 

Therefore I've removed it and made this PR, merge if you want :)
Be sure to re-run `npm i` or `yarn` to actualize your lock files.

Beep boop, I'm a bot.
